### PR TITLE
Add optional field for Fine Grained Access Token

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,6 +68,8 @@
                     <div class="form-group row">
                         <input type="text" class="form-control dark-input" id="github-username"
                             placeholder="Github Username" name="github-username" required>
+                        <input type="text" class="form-control dark-input" id="github-access-token"
+                            placeholder="Github Fine Grained Access Token (optional)" name="github-access-token" title="Rate limit for unauthenticated requests is 60 requests per hour. Access Token Required for accounts with large follower/following counts." optional>
                     </div>
                     <div class="form-group row">
                         <button type="submit" class="btn btn-outline-warning btn-block"> <i class="fa fa-search"

--- a/js/script.js
+++ b/js/script.js
@@ -145,6 +145,7 @@ async function fetchPaginatedData(url, accessToken) {
             response = await fetch(url + `?page=${page}&per_page=100`, {
                 headers: {
                     "Authorization": `Bearer ${accessToken}`,
+                    "X-GitHub-Api-Version": "2022-11-28"
                 }
             });
         }

--- a/js/script.js
+++ b/js/script.js
@@ -16,8 +16,9 @@ $(document).ready(function () {
         $('#form').hide();
 
         githubUsername = $('#github-username').val();
+        githubFineGrainAccessToken = $('#github-access-token').val();
 
-        authenticateAndFetchData(githubUsername);
+        authenticateAndFetchData(githubUsername, githubFineGrainAccessToken);
     });
 
     // search new user
@@ -87,13 +88,13 @@ function hideLoading() {
 }
 
 ////////// fetch followers data //////////
-async function authenticateAndFetchData(username) {
+async function authenticateAndFetchData(username, accessToken) {
     try {
         const userResponse = await fetch(`https://api.github.com/users/${username}`);
         const user = await userResponse.json();
 
-        const followers = await fetchAllFollowers(username);
-        const followings = await fetchAllFollowings(username);
+        const followers = await fetchAllFollowers(username, accessToken);
+        const followings = await fetchAllFollowings(username, accessToken);
 
         $('#userImage').attr('src', user.avatar_url);
         $('#userName').text(user.login);
@@ -124,22 +125,29 @@ async function authenticateAndFetchData(username) {
     }
 }
 
-function fetchAllFollowers(username) {
-    return fetchPaginatedData(`https://api.github.com/users/${username}/followers`);
+function fetchAllFollowers(username, accessToken) {
+    return fetchPaginatedData(`https://api.github.com/users/${username}/followers`, accessToken);
 }
 
-function fetchAllFollowings(username) {
-    return fetchPaginatedData(`https://api.github.com/users/${username}/following`);
+function fetchAllFollowings(username, accessToken) {
+    return fetchPaginatedData(`https://api.github.com/users/${username}/following`, accessToken);
 }
 
-async function fetchPaginatedData(url) {
+async function fetchPaginatedData(url, accessToken) {
     let allData = [];
     let page = 1;
     let response;
 
     do {
-        response = await fetch(url + `?page=${page}&per_page=100`, {
-        });
+        if (accessToken === "") {
+            response = await fetch(url + `?page=${page}&per_page=100`, { });
+        } else {
+            response = await fetch(url + `?page=${page}&per_page=100`, {
+                headers: {
+                    "Authorization": `Bearer ${accessToken}`,
+                }
+            });
+        }
 
         if (!response.ok) {
             throw new Error(`Request failed with status ${response.status}`);
@@ -275,7 +283,7 @@ function displayFollowingsDiv() {
 }
 
 function displayFollowersNotFollowing() {
-    const itemsPerPage = 8;
+    const itemsPerPage = 100;
     displayDataDiv(
         followersNotFollowing,
         '#followers-not-following-count',
@@ -290,7 +298,7 @@ function displayFollowersNotFollowing() {
 }
 
 function displayFollowingNotFollowers() {
-    const itemsPerPage = 8;
+    const itemsPerPage = 100;
     displayDataDiv(
         followingNotFollowers,
         '#following-not-followers-count',


### PR DESCRIPTION
-allow user to add their github token to increase rate limit; default unauthorized API rate limit is 60 per hour, this breaks the tool for accounts with large follower/following counts. 

-increase default profile count from 8 to 100 (should this be user configurable?)

proposed fix for #1


usage:

1. generate fine-grained personal access token in github settings: https://docs.github.com/en/rest/authentication/authenticating-to-the-rest-api?apiVersion=2022-11-28#authenticating-with-a-personal-access-token
2. paste token in token input (token is not saved server side, only sent as rest header)

This increases limit rate to 5000 request per hour: https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#primary-rate-limit-for-unauthenticated-users